### PR TITLE
feat: add zen-method to register item subtypes by NBT to JEI

### DIFF
--- a/src/main/java/ink/ikx/rt/api/mods/jei/JEIExpansion.java
+++ b/src/main/java/ink/ikx/rt/api/mods/jei/JEIExpansion.java
@@ -1,14 +1,19 @@
 package ink.ikx.rt.api.mods.jei;
 
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import ink.ikx.rt.impl.mods.jei.JeiPlugin;
 import youyihj.zenutils.api.zenscript.SidedZenRegister;
 import ink.ikx.rt.api.mods.jei.core.IJeiPanel;
 import ink.ikx.rt.api.mods.jei.core.IJeiRecipe;
+import net.minecraft.item.ItemStack;
 
 import ink.ikx.rt.impl.mods.jei.impl.core.MCJeiPanel;
 import ink.ikx.rt.impl.mods.jei.impl.core.MCJeiRecipe;
 import stanhebben.zenscript.annotations.ZenExpansion;
 import stanhebben.zenscript.annotations.ZenMethodStatic;
 
+import java.util.Objects;
 
 @SidedZenRegister(modDeps = "jei")
 @ZenExpansion("mods.jei.JEI")
@@ -24,4 +29,10 @@ public abstract class JEIExpansion {
         return new MCJeiRecipe(uid);
     }
 
+    @ZenMethodStatic
+    public static void addItemNBTSubtype(IItemStack stack) {
+        ItemStack mcStack = CraftTweakerMC.getItemStack(stack);
+        Objects.requireNonNull(mcStack.getItem());
+        JeiPlugin.subtypesToRegister.add(mcStack.getItem());
+    }
 }

--- a/src/main/java/ink/ikx/rt/impl/mods/jei/JeiPlugin.java
+++ b/src/main/java/ink/ikx/rt/impl/mods/jei/JeiPlugin.java
@@ -10,11 +10,14 @@ import ink.ikx.rt.impl.mods.jei.recipe.DynamicRecipesWrapper;
 import mezz.jei.Internal;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.ISubtypeRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.gui.GuiHelper;
+import net.minecraft.item.Item;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +26,12 @@ import java.util.stream.Collectors;
 public class JeiPlugin implements IModPlugin {
 
     public static final String DEFAULT_TEXTURE = "randomtweaker:textures/gui/jei/jei_default.png";
+    public static List<Item> subtypesToRegister = new ArrayList<>();
+
+    @Override
+    public void registerItemSubtypes(ISubtypeRegistry subtypeRegistry) {
+        subtypeRegistry.useNbtForSubtypes(subtypesToRegister.toArray(new Item[0]));
+    }
 
     @Override
     public void registerCategories(IRecipeCategoryRegistration registry) {


### PR DESCRIPTION
I would like to use this mod to make a custom JEI category and recipes with a certain custom item. The item is an input to many recipes I have created, but the only difference in input between the recipes is its NBT. This makes it difficult to know which recipe corresponds to which item with NBT, as JEI will show **all** recipes using this item, ignoring NBT. 

Utilizing `IModPlugin.registerItemSubtypes()` to distinguish between all the items with different NBT would fix this problem I have. So this PR is a simple addition to allow CraftTweaker script writers to use full NBT as comparison for registering item subtypes. Any `ISubtypeInterpreter` more complex than that is out of scope for this PR.

Adds ZenMethod `mods.jei.JEI.addItemNBTSubtype(ItemStack)` to do this.

Thanks in advance for taking a look and hope this can be accepted and pushed into a release when you have the time.